### PR TITLE
Add dedicated JSON response system

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ Route::get('/', function () {
 });
 ```
 
+
+Example of a JSON response:
+
+```php
+Route::get('/health', function () {
+    return json_response([
+        'status' => 'ok',
+        'framework' => 'arpon',
+    ]);
+});
+```
+
 ## Author
 
 **Arpon** - [GitHub](https://github.com/arponascension1)

--- a/src/Arpon/Http/JsonResponse.php
+++ b/src/Arpon/Http/JsonResponse.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Arpon\Http;
+
+use JsonException;
+
+class JsonResponse extends Response
+{
+    protected int $encodingOptions;
+
+    public function __construct($data = [], int $statusCode = 200, array $headers = [], int $encodingOptions = 0)
+    {
+        $this->encodingOptions = $encodingOptions;
+
+        $headers['Content-Type'] = $headers['Content-Type'] ?? 'application/json';
+
+        parent::__construct($this->encode($data), $statusCode, $headers);
+    }
+
+    public function setData($data): static
+    {
+        $this->setContent($this->encode($data));
+
+        return $this;
+    }
+
+    public function getEncodingOptions(): int
+    {
+        return $this->encodingOptions;
+    }
+
+    public function setEncodingOptions(int $encodingOptions): static
+    {
+        $this->encodingOptions = $encodingOptions;
+
+        return $this;
+    }
+
+    protected function encode($data): string
+    {
+        try {
+            return json_encode($data, $this->encodingOptions | JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new \InvalidArgumentException('Unable to encode data to JSON: ' . $e->getMessage(), 0, $e);
+        }
+    }
+}
+

--- a/src/Arpon/Http/Response.php
+++ b/src/Arpon/Http/Response.php
@@ -94,9 +94,7 @@ class Response
 
     public function json($data = [], $statusCode = 200, $headers = [])
     {
-        $headers['Content-Type'] = 'application/json';
-        
-        return new Response(json_encode($data), $statusCode, $headers);
+        return new JsonResponse($data, $statusCode, $headers);
     }
 
     public function redirect($url, $statusCode = 302)

--- a/src/Arpon/Support/helpers.php
+++ b/src/Arpon/Support/helpers.php
@@ -98,6 +98,24 @@ if (!function_exists('response')) {
  * @param int $statusCode
  * @return \Arpon\View\View
  */
+
+
+/**
+ * Create a new JSON response instance.
+ *
+ * @param mixed $data
+ * @param int $statusCode
+ * @param array $headers
+ * @param int $encodingOptions
+ * @return \Arpon\Http\JsonResponse
+ */
+if (!function_exists('json_response')) {
+    function json_response($data = [], $statusCode = 200, $headers = [], $encodingOptions = 0)
+    {
+        return new \Arpon\Http\JsonResponse($data, $statusCode, $headers, $encodingOptions);
+    }
+}
+
 if (!function_exists('view')) {
     function view($view, $data = [], $statusCode = 200)
     {


### PR DESCRIPTION
### Motivation
- Provide a centralized, robust JSON response type to ensure consistent encoding, proper Content-Type headers, and clear error handling for JSON APIs.

### Description
- Add a new `Arpon\Http\JsonResponse` class that extends `Response` and encodes data using `JSON_THROW_ON_ERROR` with configurable encoding options.
- Update `Response::json()` to return `JsonResponse` so JSON responses are created via the new dedicated class.
- Add a global helper `json_response()` to quickly create `JsonResponse` instances with status, headers, and encoding flags.
- Document usage in `README.md` with a `/health` example demonstrating `json_response()`.

### Testing
- Ran syntax checks with `php -l` on `src/Arpon/Http/JsonResponse.php`, `src/Arpon/Http/Response.php`, and `src/Arpon/Support/helpers.php`, which reported no syntax errors (success).
- Ran `composer test` in this environment which failed because `vendor/bin/phpunit` is not installed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b4a04a2d88328a77035ba25f4b3a6)